### PR TITLE
Rename the Project

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{
-				allowedTextDomain: 'wp-entities-search',
+				allowedTextDomain: 'kensaku',
 			},
 		],
 		'@typescript-eslint/array-type': [ 'error', { default: 'generic' } ],

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,7 +5,7 @@
     "development": {
       "phpVersion": "8.1",
       "mappings": {
-        "wp-content/plugins/wp-entities-search": "."
+        "wp-content/plugins/kensaku": "."
       }
     }
   },

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -4,10 +4,10 @@ import { BaseEntityRecords, Context } from '@wordpress/core-data';
 
 import type { Set } from '../sources/client/src';
 
-export default EntitiesSearch;
+export default Kensaku;
 
 // TODO Try to convert it to a module.
-declare namespace EntitiesSearch {
+declare namespace Kensaku {
 	type Post<C extends Context = 'view'> = BaseEntityRecords.Post<C>;
 	type PostType<C extends Context = 'view'> = BaseEntityRecords.Type<C>;
 	type Taxonomy<C extends Context = 'view'> = BaseEntityRecords.Taxonomy<C>;
@@ -23,7 +23,7 @@ declare namespace EntitiesSearch {
 			Readonly<{
 				exclude: Set<string | number>;
 				include: Set<string | number>;
-				fields: EntitiesSearch.SearchQueryFields;
+				fields: Kensaku.SearchQueryFields;
 				[p: string]: unknown;
 			}>
 		> {}
@@ -42,7 +42,7 @@ declare namespace EntitiesSearch {
 	type SearchEntitiesFunction<E, K> = (
 		phrase: string,
 		kind: Kind<K>,
-		queryArguments?: EntitiesSearch.QueryArguments<E>
+		queryArguments?: Kensaku.QueryArguments<E>
 	) => Promise<Options<E>>;
 
 	type SingularControl<V> = {
@@ -104,7 +104,7 @@ declare namespace EntitiesSearch {
 	 */
 	// TODO Better to convert the SearchQueryFields to a Set.
 	type SearchQueryFields = ReadonlyArray<
-		keyof EntitiesSearch.SearchEntityFields
+		keyof Kensaku.SearchEntityFields
 	>;
 
 	/*
@@ -113,7 +113,7 @@ declare namespace EntitiesSearch {
 	interface EntitiesState<
 		E,
 		K,
-		OptionSet = Set<EntitiesSearch.ControlOption<E>>
+		OptionSet = Set<Kensaku.ControlOption<E>>
 	> extends Readonly<{
 			entities: Entities<E>;
 			kind: Kind<K>;
@@ -150,7 +150,7 @@ declare namespace EntitiesSearch {
 		  }
 		| {
 				type: 'UPDATE_ENTITIES_OPTIONS_FOR_NEW_KIND';
-				entitiesOptions: Set<EntitiesSearch.ControlOption<E>>;
+				entitiesOptions: Set<Kensaku.ControlOption<E>>;
 				kind: EntitiesState<E, K>['kind'];
 		  }
 		| {

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Wp Entities Search
+# Kensaku
 
 > A WordPress package to search Entities including Rest API Endpoints and React Components
 
-[![JS Quality Assurance](https://github.com/spaghetti-dojo/wp-entities-search/actions/workflows/js-qa.yml/badge.svg)](https://github.com/spaghetti-dojo/wp-entities-search/actions/workflows/js-qa.yml)
-[![PHP Quality Assurance](https://github.com/spaghetti-dojo/wp-entities-search/actions/workflows/php-qa.yml/badge.svg)](https://github.com/spaghetti-dojo/wp-entities-search/actions/workflows/php-qa.yml)
+[![JS Quality Assurance](https://github.com/spaghetti-dojo/kensaku/actions/workflows/js-qa.yml/badge.svg)](https://github.com/spaghetti-dojo/kensaku/actions/workflows/js-qa.yml)
+[![PHP Quality Assurance](https://github.com/spaghetti-dojo/kensaku/actions/workflows/php-qa.yml/badge.svg)](https://github.com/spaghetti-dojo/kensaku/actions/workflows/php-qa.yml)
 
 This package is a library exposing reusable Components and Utilities to help you build Entities searching and storage.
 
@@ -12,7 +12,7 @@ more Post Types but also, to search for Terms belonging to one or more Taxonomie
 
 ## Documentation
 
-Go to [documentation](./docs) or visit the site [wp-entities-search](https://spaghetti-dojo.github.io/wp-entities-search/).
+Go to [documentation](./docs) or visit the site [kensaku](https://spaghetti-dojo.github.io/kensaku/).
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-  "name": "spaghetti-dojo/wp-entities-search",
+  "name": "spaghetti-dojo/kensaku",
   "description": "A WordPress package to search Entities including Rest API Endpoints and React Components",
   "type": "library",
   "license": "GPL-2.0-or-later",
   "autoload": {
     "psr-4": {
-      "SpaghettiDojo\\Wp\\EntitiesSearch\\": "sources/server/src/"
+      "SpaghettiDojo\\Kensaku\\": "sources/server/src/"
     }
   },
   "authors": [

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,20 +1,20 @@
-title: Wp Entities Search
+title: Kensaku
 description: >-
   A WordPress package to search Entities including Rest API Endpoints and React Components
-url: "https://spaghetti-dojo.github.io/wp-entities-search"
-baseurl: "/wp-entities-search"
+url: "https://spaghetti-dojo.github.io/kensaku"
+baseurl: "/kensaku"
 
 remote_theme: just-the-docs/just-the-docs
 
 aux_links:
-  "Wp Entities Search on Github":
-    - "https://github.com/spaghetti-dojo/wp-entities-search"
+  "Kensaku on Github":
+    - "https://github.com/spaghetti-dojo/kensaku"
 
 aux_links_new_tab: true
 
 nav_external_links:
   - title: Go to the Repository
-    url: https://github.com/spaghetti-dojo/wp-entities-search
+    url: https://github.com/spaghetti-dojo/kensaku
     opens_in_new_tab: true
 
 back_to_top: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -14,7 +14,7 @@ The package provide then the following functions to interact with the WordPress 
 
 This function is a wrapper for the Search Endpoint of the WordPress API. It will return a `Set` of entities matching the search query.
 
-The possible query arguments are specified by the `EntitiesSearch.QueryArguments` type, an interface you can expand to add more arguments.
+The possible query arguments are specified by the `Kensaku.QueryArguments` type, an interface you can expand to add more arguments.
 
 This function is not directly consumed by the components, and it is not intended to be used internally. The idea is to follow the Tell don't Ask principle and let the consumer specify how to search the Entities.
 
@@ -22,7 +22,7 @@ Below a possible example of its usage related to a component:
 
 ```tsx
 // my-component.tsx
-type Search = EntitiesSearch.SearchEntitiesFunction<string, string>;
+type Search = Kensaku.SearchEntitiesFunction<string, string>;
 type Props = {
     search: Search
 }
@@ -48,7 +48,7 @@ const MyComponent (props: Props) => {
 }
 
 // index.tsx
-import {searchEntities} from 'wp-entities-search';
+import {searchEntities} from 'kensaku';
 
 root.render(<MyComponent search={searchEntities} />);
 ```
@@ -60,7 +60,7 @@ The function accept four parameters
 - `type` - The root type. We have two built-int supported types `post`, `term`.
 - `subtype` - The subtype of the entity. For example, if the `type` is `post`, the `subtype` can be `page`, `post`, etc. WordPress exclude automatically the `attachment` subtype.
 - `phrase` - The search phrase. This becomes the `s` parameter for the Search Endpoint.
-- `queryArguments` - All the supported and extra query arguments. The `EntitiesSearch.QueryArguments` type is an interface you can expand to add more arguments.
+- `queryArguments` - All the supported and extra query arguments. The `Kensaku.QueryArguments` type is an interface you can expand to add more arguments.
 
 ### Return
 
@@ -77,7 +77,7 @@ The `searchEntities` will automatically abort the requests with the same paramet
 ## `searchEntitiesOptions`
 
 This function is a wrapper for the `searchEntites` which perform a small additional task you might want to do quite ofter after retrieving the entities that is
-to convert the entities to `EntitiesSearch.ControlOptions`. The argument taken are the same of the `searchEntities`.
+to convert the entities to `Kensaku.ControlOptions`. The argument taken are the same of the `searchEntities`.
 
 ### `createSearchEntitiesOptions`
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -6,7 +6,7 @@ nav_order: 4
 
 # Components
 
-The Wp Entities Search provides a set of components you can use to build your search UI.
+Kensaku provides a set of components you can use to build your search UI.
 
 We have to distinguish between two types of components:
 
@@ -57,7 +57,7 @@ possible to use a search function in conjunction with a `search` field.
 An example of its usage is:
 
 ```jsx
-import { CompositeEntitiesByKind } from 'wp-entities-search';
+import { CompositeEntitiesByKind } from 'kensaku';
 
 export function MyComponent(props) {
     const entities = {
@@ -146,7 +146,7 @@ In the example below we only allow to select the entities belonging to the `page
 the user to switch between them.
 
 ```jsx
-import { CompositeEntitiesByKind } from 'wp-entities-search';
+import { CompositeEntitiesByKind } from 'kensaku';
 
 export function MyComponent(props) {
     const entities = {
@@ -228,11 +228,11 @@ Therefore, the preset simplify and take care of some parts that you would have t
 
 - `entitiesFinder` - The function which perform the search of the contextual entities. You can use the `createSearchEntitiesOptions` function by passing the `root` value such as `term` or `post`.
 - `className` - For better customization you can pass your own custom classes.
-- `entities` - A `EntitiesSearch.Entities` set of selected entities. For when you want some entities already selected.
+- `entities` - A `Kensaku.Entities` set of selected entities. For when you want some entities already selected.
 - `onChangeEntities` - A task to perform when the selection change due to a user interaction.
 - `entitiesComponent` - The component to use to render the control ui for the entities.
 - `kind` - The predefined set of kind (e.g. post-types or taxonomies) you want to have already selected.
-- `kindOptions` - A collection of `EntitiesSearch.ControlOption` among which the user can choose to retrieve the entities from.
+- `kindOptions` - A collection of `Kensaku.ControlOption` among which the user can choose to retrieve the entities from.
 - `onChangeKind` - A task to perform when the selection change due to a user interaction.
 - `kindComponent` - The component to use to render the control ui for the kinds.
 - `entitiesFields` - Additional fields you want to retrieve and have available within your `entitiesComponent` and `kindComponent`. For more info read the [Control Option](./control-option.md) documentation.
@@ -246,7 +246,7 @@ The Singular Components always get a single value, therefore you have to conside
 the `Set`.
 
 ```jsx
-import { CompositeEntitiesByKind } from 'wp-entities-search';
+import { CompositeEntitiesByKind } from 'kensaku';
 
 export function MyComponent(props) {
     return <CompositeEntitiesByKind

--- a/docs/control-option.md
+++ b/docs/control-option.md
@@ -18,7 +18,7 @@ An additional data structure is part of the `EnrichedControlOption` interface im
 not consumed within any of the _Base_ or _Composite_ components of the project, it is there to permit the third parties
 to customize the UI.
 
-The `extra` property is of type `EntitiesSearch.Record`; it can hold a heterogeneous set of properties, we do not check
+The `extra` property is of type `Kensaku.Record`; it can hold a heterogeneous set of properties, we do not check
 against values or types, this is up to the consumer.
 
 ## About the Value
@@ -27,7 +27,7 @@ The `value` is a generic type to give the possibility to customize the shape of 
 implement they own components, and therefore we do not want to pose any restriction.
 
 Nonetheless, the possible types the `value` can assume within the project Components is `string | number`;
-see `EntitiesSearch.Value` type for more info.
+see `Kensaku.Value` type for more info.
 
 ## How to use the Extra Property
 
@@ -65,10 +65,10 @@ searchEntities: async (
 ```
 
 Then you can access the extra properties within your component since the `CompositeEntitiesByKind` will pass
-the `entities` of type `EntitiesSearch.BaseControl< E >` to the children.
+the `entities` of type `Kensaku.BaseControl< E >` to the children.
 
 ```jsx
-(entities: EntitiesSearch.BaseControl< E >) => {
+(entities: Kensaku.BaseControl< E >) => {
     return <MyComponent {...entities} />;
 }
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,8 +9,8 @@ nav_order: 2
 The first thing to do is to clone the repository and install the dependencies:
 
 ```bash
-$ git clone git@github.com:spaghetti-dojo/wp-entities-search.git
-$ cd wp-entities-search
+$ git clone git@github.com:spaghetti-dojo/kensaku.git
+$ cd kensaku
 $ composer install
 $ yarn install
 ```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -6,7 +6,7 @@ nav_order: 6
 
 # Hooks
 
-The Wp Entities Search expose some hooks to help you to work with the search and the rest calls.
+Kensaku expose some hooks to help you to work with the search and the rest calls.
 
 - `useEntitiesOptionsStorage`
 - `useEntitiesRecords`
@@ -64,7 +64,7 @@ endpoint.
 The following example is retrieving the list of the `postType`s from the server.
 
 ```ts
-const entitiesRecords = useEntityRecords<EntitiesSearch.PostType<'edit'>>(
+const entitiesRecords = useEntityRecords<Kensaku.PostType<'edit'>>(
     'root',
     'postType',
     { per_page: -1 }
@@ -94,5 +94,5 @@ It requires a function `searchEntities` to perform the search to the server, the
 query for the new entities values. In the future there'll be the possibility to reuse the storage directly from within
 the hook reducing the amount of parameters, and for last the `dispatch`, necessary to update the shared state.
 
-When the state update fail for any reason an action `wp-entities-search.on-search.error` is fired. You can hook into it
+When the state update fail for any reason an action `kensaku.on-search.error` is fired. You can hook into it
 and consume the given `error` instance. More on this in the [logging](./logging.md) documentation.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -94,5 +94,5 @@ It requires a function `searchEntities` to perform the search to the server, the
 query for the new entities values. In the future there'll be the possibility to reuse the storage directly from within
 the hook reducing the amount of parameters, and for last the `dispatch`, necessary to update the shared state.
 
-When the state update fail for any reason an action `kensaku.on-search.error` is fired. You can hook into it
+When the state update fails for any reason, an action `kensaku.on-search.error` is fired. You can hook into it
 and consume the given `error` instance. More on this in the [logging](./logging.md) documentation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ The JavaScript implementation is composed of a set of utilities and React compon
 To install the package as part of the composer dependencies of your project, run the following command:
 
 ```bash
-composer require spaghetti-dojo/wp-entities-search
+composer require spaghetti-dojo/kensaku
 ```
 
 ## NPM

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -18,8 +18,8 @@ For instance, below you can see an example of one of the actions error logging.
 
 ```ts
 addAction(
-	'wp-entities-search.on-change-entities.error',
-	'wp-entities-search/wp-on-change-entities.error',
+	'kensaku.on-change-entities.error',
+	'kensaku/wp-on-change-entities.error',
 	(error) => {
 		console.error(
 			`Composite Entities by Kind - on Change Entities: ${

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 ---
 layout: home
-title: Wp Entities Search
+title: Kensaku
 permalink: /
 nav_order: 0
 ---

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-entities-search",
+	"name": "kensaku",
 	"description": "A WordPress package to search Entities including Rest API Endpoints and React Components",
 	"author": "guido scialfa <dev@guidoscialfa.com>",
 	"main": "./build/index.js",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,7 +6,7 @@
     <arg name="colors"/>
     <arg name="extensions" value="php,inc"/>
 
-	<config name="text_domain" value="wp-entities-search"/>
+	<config name="text_domain" value="kensaku"/>
     <config name="testVersion" value="8.1-"/>
     <config name="ignore_warnings_on_exit" value="1"/>
 

--- a/plugin.php
+++ b/plugin.php
@@ -1,18 +1,18 @@
 <?php
 
 /**
- * Plugin Name: Wp Entities Search
+ * Plugin Name: Kensaku
  * Author: Guido Scialfa
- * Description: The WordPress plugin to develop the Wp Search Entities library.
+ * Description: The WordPress plugin to develop the Kensaku entities search library.
  * Author URI: https://guidoscialfa.com/
  */
 
 declare(strict_types=1);
 
-namespace SpaghettiDojo\Wp\EntitiesSearch;
+namespace SpaghettiDojo\Kensaku;
 
 use Inpsyde\Modularity;
-use SpaghettiDojo\Wp\EntitiesSearch;
+use SpaghettiDojo\Kensaku;
 
 function package(): Modularity\Package
 {
@@ -33,7 +33,7 @@ function package(): Modularity\Package
 
     if (!$package) {
         autoload($projectRoot);
-        $package = EntitiesSearch\Library::new(\plugin_dir_url(__FILE__))->package();
+        $package = Kensaku\Library::new(\plugin_dir_url(__FILE__))->package();
     }
 
     return $package;
@@ -42,6 +42,6 @@ function package(): Modularity\Package
 \add_action(
     'plugins_loaded',
     fn() => package()
-        ->addModule(EntitiesSearch\Modules\E2e\Module::new())
+        ->addModule(Kensaku\Modules\E2e\Module::new())
         ->boot()
 );

--- a/sources/client/src/api/create-search-entities-options.ts
+++ b/sources/client/src/api/create-search-entities-options.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -12,8 +12,8 @@ import { searchEntitiesOptions } from './search-entities-options';
 export function createSearchEntitiesOptions< E >( type: string ) {
 	return async (
 		phrase: string,
-		postTypes: EntitiesSearch.Kind< string >,
-		queryArguments?: EntitiesSearch.QueryArguments
-	): Promise< Set< EntitiesSearch.ControlOption< E > > > =>
+		postTypes: Kensaku.Kind< string >,
+		queryArguments?: Kensaku.QueryArguments
+	): Promise< Set< Kensaku.ControlOption< E > > > =>
 		searchEntitiesOptions( type, phrase, postTypes, queryArguments );
 }

--- a/sources/client/src/api/search-entities-options.ts
+++ b/sources/client/src/api/search-entities-options.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -13,11 +13,11 @@ import { convertEntitiesToControlOptions } from '../utils/convert-entities-to-co
 export async function searchEntitiesOptions< E >(
 	type: string,
 	phrase: string,
-	postTypes: EntitiesSearch.Kind< string >,
-	queryArguments?: EntitiesSearch.QueryArguments
-): Promise< Set< EntitiesSearch.ControlOption< E > > > {
+	postTypes: Kensaku.Kind< string >,
+	queryArguments?: Kensaku.QueryArguments
+): Promise< Set< Kensaku.ControlOption< E > > > {
 	const postsEntities =
-		await searchEntities< EntitiesSearch.SearchEntityFields >(
+		await searchEntities< Kensaku.SearchEntityFields >(
 			type,
 			postTypes,
 			phrase,

--- a/sources/client/src/api/search-entities-options.ts
+++ b/sources/client/src/api/search-entities-options.ts
@@ -16,13 +16,12 @@ export async function searchEntitiesOptions< E >(
 	postTypes: Kensaku.Kind< string >,
 	queryArguments?: Kensaku.QueryArguments
 ): Promise< Set< Kensaku.ControlOption< E > > > {
-	const postsEntities =
-		await searchEntities< Kensaku.SearchEntityFields >(
-			type,
-			postTypes,
-			phrase,
-			queryArguments
-		);
+	const postsEntities = await searchEntities< Kensaku.SearchEntityFields >(
+		type,
+		postTypes,
+		phrase,
+		queryArguments
+	);
 
 	const { fields = [] } = queryArguments ?? {};
 	const [ label = 'title', value = 'id', ...extraFields ] = fields;

--- a/sources/client/src/api/search-entities.ts
+++ b/sources/client/src/api/search-entities.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * WordPress dependencies
@@ -20,7 +20,7 @@ export async function searchEntities< E >(
 	type: string,
 	subtype: Set< string >,
 	phrase: string,
-	queryArguments?: EntitiesSearch.QueryArguments
+	queryArguments?: Kensaku.QueryArguments
 ): Promise< Set< E > > {
 	const {
 		exclude,
@@ -57,7 +57,7 @@ export async function searchEntities< E >(
 		signal: controller?.signal() ?? null,
 	} ).catch( ( error ) => {
 		if ( error instanceof DOMException && error.name === 'AbortError' ) {
-			doAction( 'wp-entities-search.on-search.abort', error );
+			doAction( 'kensaku.on-search.abort', error );
 		}
 
 		throw error;
@@ -66,6 +66,6 @@ export async function searchEntities< E >(
 	return new Set( entities );
 }
 
-function serializeFields( fields: EntitiesSearch.SearchQueryFields ): string {
+function serializeFields( fields: Kensaku.SearchQueryFields ): string {
 	return fields.join( ',' );
 }

--- a/sources/client/src/components/composite-entities-by-kind.tsx
+++ b/sources/client/src/components/composite-entities-by-kind.tsx
@@ -75,10 +75,7 @@ export function CompositeEntitiesByKind< E, K >(
 				} );
 			} )
 			.catch( ( error ) => {
-				doAction(
-					'kensaku.on-change-entities.error',
-					error
-				);
+				doAction( 'kensaku.on-change-entities.error', error );
 			} );
 	};
 

--- a/sources/client/src/components/composite-entities-by-kind.tsx
+++ b/sources/client/src/components/composite-entities-by-kind.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type EntitiesSearch from '@types';
+import type Kensaku from '@types';
 import React, { JSX } from 'react';
 
 /**
@@ -25,7 +25,7 @@ import { Set } from '../models/set';
  * @param props The component props.
  */
 export function CompositeEntitiesByKind< E, K >(
-	props: EntitiesSearch.CompositeEntitiesKinds< E, K >
+	props: Kensaku.CompositeEntitiesKinds< E, K >
 ): JSX.Element {
 	const [ state, dispatch ] = useEntitiesOptionsStorage< E, K >(
 		{
@@ -41,7 +41,7 @@ export function CompositeEntitiesByKind< E, K >(
 		dispatch
 	);
 
-	const onChangeEntities = ( entities: EntitiesSearch.Entities< E > ) => {
+	const onChangeEntities = ( entities: Kensaku.Entities< E > ) => {
 		props.entities.onChange( entities );
 
 		if ( entities.length() <= 0 ) {
@@ -76,13 +76,13 @@ export function CompositeEntitiesByKind< E, K >(
 			} )
 			.catch( ( error ) => {
 				doAction(
-					'wp-entities-search.on-change-entities.error',
+					'kensaku.on-change-entities.error',
 					error
 				);
 			} );
 	};
 
-	const onChangeKind = ( kind: EntitiesSearch.Kind< K > ) => {
+	const onChangeKind = ( kind: Kensaku.Kind< K > ) => {
 		const emptySet = new Set< any >();
 
 		props.kind.onChange( kind );
@@ -111,11 +111,11 @@ export function CompositeEntitiesByKind< E, K >(
 				dispatch( {
 					type: 'CLEAN_ENTITIES_OPTIONS',
 				} );
-				doAction( 'wp-entities-search.on-change-kind.error', error );
+				doAction( 'kensaku.on-change-kind.error', error );
 			} );
 	};
 
-	const entities: EntitiesSearch.BaseControl< E > = {
+	const entities: Kensaku.BaseControl< E > = {
 		...props.entities,
 		value: state.entities,
 		options: orderSelectedOptionsAtTheTop< E >(
@@ -129,7 +129,7 @@ export function CompositeEntitiesByKind< E, K >(
 		onChange: onChangeEntities,
 	};
 
-	const kind: EntitiesSearch.BaseControl< K > = {
+	const kind: Kensaku.BaseControl< K > = {
 		...props.kind,
 		value: state.kind,
 		onChange: onChangeKind,

--- a/sources/client/src/components/no-options-message.tsx
+++ b/sources/client/src/components/no-options-message.tsx
@@ -10,8 +10,8 @@ import { __ } from '@wordpress/i18n';
 
 export function NoOptionsMessage(): JSX.Element {
 	return (
-		<p className="wes-no-option-message">
-			{ __( 'No options', 'wp-entities-search' ) }
+		<p className="kensaku-no-option-message">
+			{ __( 'No options', 'kensaku' ) }
 		</p>
 	);
 }

--- a/sources/client/src/components/plural-select-control.tsx
+++ b/sources/client/src/components/plural-select-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import classnames from 'classnames';
 import React, { JSX } from 'react';
 
@@ -12,15 +12,15 @@ import { Set } from '../models/set';
 import { NoOptionsMessage } from './no-options-message';
 
 export function PluralSelectControl(
-	props: EntitiesSearch.BaseControl< EntitiesSearch.Value > & {
+	props: Kensaku.BaseControl< Kensaku.Value > & {
 		className?: string;
 	}
 ): JSX.Element {
 	const [ selected, setSelected ] = React.useState( props.value );
 	const className = classnames(
 		props.className,
-		'wes-select-control',
-		'wes-select-control--plural'
+		'kensaku-select-control',
+		'kensaku-select-control--plural'
 	);
 
 	const onChange = ( event: React.ChangeEvent< HTMLSelectElement > ) => {
@@ -55,7 +55,7 @@ export function PluralSelectControl(
 			{ props.options.map( ( option ) => (
 				<option
 					key={ option.value }
-					className={ `wes-select-control-item wes-select-control-item--${ option.value }` }
+					className={ `kensaku-select-control-item kensaku-select-control-item--${ option.value }` }
 					value={ option.value }
 				>
 					{ option.label }

--- a/sources/client/src/components/preset-entities-by-kind.tsx
+++ b/sources/client/src/components/preset-entities-by-kind.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React, { JSX } from 'react';
 import classnames from 'classnames';
 
@@ -17,21 +17,21 @@ import { CompositeEntitiesByKind } from './composite-entities-by-kind';
 import { SearchControl } from './search-control';
 import { Set } from '../models/set';
 
-type EntitiesValue = EntitiesSearch.Value;
-type Entities = EntitiesSearch.Entities< EntitiesValue >;
-type KindValue = EntitiesSearch.Kind< string > | string;
+type EntitiesValue = Kensaku.Value;
+type Entities = Kensaku.Entities< EntitiesValue >;
+type KindValue = Kensaku.Kind< string > | string;
 
 type EntitiesFinder = (
 	phrase: string,
-	kind: EntitiesSearch.Kind< string >,
-	queryArguments?: EntitiesSearch.QueryArguments
-) => Promise< Set< EntitiesSearch.ControlOption< EntitiesValue > > >;
+	kind: Kensaku.Kind< string >,
+	queryArguments?: Kensaku.QueryArguments
+) => Promise< Set< Kensaku.ControlOption< EntitiesValue > > >;
 
 type EntitiesComponent = React.ComponentType<
-	EntitiesSearch.BaseControl< EntitiesValue >
+	Kensaku.BaseControl< EntitiesValue >
 >;
 type KindComponent = React.ComponentType<
-	EntitiesSearch.BaseControl< KindValue >
+	Kensaku.BaseControl< KindValue >
 >;
 
 type PublicComponentProps = {
@@ -41,15 +41,15 @@ type PublicComponentProps = {
 	onChangeEntities: ( values: Entities ) => void;
 	entitiesComponent: EntitiesComponent;
 	kind: KindValue;
-	kindOptions: EntitiesSearch.Options< string >;
+	kindOptions: Kensaku.Options< string >;
 	onChangeKind: ( values: KindValue ) => void;
 	kindComponent: KindComponent;
-	entitiesFields?: EntitiesSearch.QueryArguments[ 'fields' ];
+	entitiesFields?: Kensaku.QueryArguments[ 'fields' ];
 };
 
 interface PrivateComponentProps
 	extends Pick<
-		EntitiesSearch.CompositeEntitiesKinds< EntitiesValue, string >,
+		Kensaku.CompositeEntitiesKinds< EntitiesValue, string >,
 		'kind' | 'entities'
 	> {
 	className?: string;
@@ -59,7 +59,7 @@ interface PrivateComponentProps
 }
 
 function PrivateComponent( props: PrivateComponentProps ): JSX.Element {
-	const className = classnames( 'wes-preset-entities-by-kind', {
+	const className = classnames( 'kensaku-preset-entities-by-kind', {
 		// @ts-ignore
 		[ props.className ]: !! props.className,
 	} );
@@ -135,12 +135,12 @@ const withDataBound = createHigherOrderComponent<
 
 function entitiesFinderWithExtraFields(
 	entitiesFinder: EntitiesFinder,
-	entitiesFields?: EntitiesSearch.QueryArguments[ 'fields' ]
+	entitiesFields?: Kensaku.QueryArguments[ 'fields' ]
 ): EntitiesFinder {
 	return (
 		phrase: string,
-		kind: EntitiesSearch.Kind< string >,
-		queryArguments?: EntitiesSearch.QueryArguments
+		kind: Kensaku.Kind< string >,
+		queryArguments?: Kensaku.QueryArguments
 	) =>
 		entitiesFinder( phrase, kind, {
 			...queryArguments,
@@ -151,7 +151,7 @@ function entitiesFinderWithExtraFields(
 		} );
 }
 
-function narrowKindValue( value: KindValue ): EntitiesSearch.Kind< string > {
+function narrowKindValue( value: KindValue ): Kensaku.Kind< string > {
 	return typeof value === 'string' ? new Set( [ value ] ) : value;
 }
 

--- a/sources/client/src/components/preset-entities-by-kind.tsx
+++ b/sources/client/src/components/preset-entities-by-kind.tsx
@@ -30,9 +30,7 @@ type EntitiesFinder = (
 type EntitiesComponent = React.ComponentType<
 	Kensaku.BaseControl< EntitiesValue >
 >;
-type KindComponent = React.ComponentType<
-	Kensaku.BaseControl< KindValue >
->;
+type KindComponent = React.ComponentType< Kensaku.BaseControl< KindValue > >;
 
 type PublicComponentProps = {
 	entitiesFinder: EntitiesFinder;

--- a/sources/client/src/components/radio-control.tsx
+++ b/sources/client/src/components/radio-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import classnames from 'classnames';
 import React, { JSX } from 'react';
 
@@ -10,18 +10,18 @@ import React, { JSX } from 'react';
  */
 import { useId } from '../hooks/use-id';
 
-interface Option< V > extends EntitiesSearch.ControlOption< V > {
-	readonly selectedValue: EntitiesSearch.SingularControl< V >[ 'value' ];
+interface Option< V > extends Kensaku.ControlOption< V > {
+	readonly selectedValue: Kensaku.SingularControl< V >[ 'value' ];
 	readonly onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }
 
 export function RadioControl(
-	props: EntitiesSearch.SingularControl< EntitiesSearch.Value > & {
+	props: Kensaku.SingularControl< Kensaku.Value > & {
 		className?: string;
 		id?: string;
 	}
 ): JSX.Element {
-	const className = classnames( props.className, 'wes-radio-control' );
+	const className = classnames( props.className, 'kensaku-radio-control' );
 
 	const onChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const { target } = event;
@@ -57,7 +57,7 @@ function Option< V >( props: Option< V > ): JSX.Element {
 
 	return (
 		<div
-			className={ `wes-radio-control-item wes-radio-control-item--${ value }` }
+			className={ `kensaku-radio-control-item kensaku-radio-control-item--${ value }` }
 		>
 			<label htmlFor={ id }>
 				<input

--- a/sources/client/src/components/search-control.tsx
+++ b/sources/client/src/components/search-control.tsx
@@ -14,9 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { useId } from '../hooks/use-id';
 
-export function SearchControl(
-	props: Kensaku.SearchControl
-): JSX.Element {
+export function SearchControl( props: Kensaku.SearchControl ): JSX.Element {
 	const id = useId( props.id );
 	const label = props.label || __( 'Search', 'kensaku' );
 	const [ searchValue, setSearchValue ] = React.useState( '' );

--- a/sources/client/src/components/search-control.tsx
+++ b/sources/client/src/components/search-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React, { JSX } from 'react';
 
 /**
@@ -15,10 +15,10 @@ import { __ } from '@wordpress/i18n';
 import { useId } from '../hooks/use-id';
 
 export function SearchControl(
-	props: EntitiesSearch.SearchControl
+	props: Kensaku.SearchControl
 ): JSX.Element {
 	const id = useId( props.id );
-	const label = props.label || __( 'Search', 'wp-entities-search' );
+	const label = props.label || __( 'Search', 'kensaku' );
 	const [ searchValue, setSearchValue ] = React.useState( '' );
 
 	const onChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
@@ -29,14 +29,14 @@ export function SearchControl(
 	const inputProps = {
 		type: 'search',
 		value: searchValue,
-		className: 'wes-search-control__input',
+		className: 'kensaku-search-control__input',
 		onChange,
 	};
 
 	return (
-		<div className="wes-search-control">
+		<div className="kensaku-search-control">
 			<label htmlFor={ id }>
-				<span className="wes-search-control__label">{ label }</span>
+				<span className="kensaku-search-control__label">{ label }</span>
 				<input id={ id } { ...inputProps } />
 			</label>
 		</div>

--- a/sources/client/src/components/singular-select-control.tsx
+++ b/sources/client/src/components/singular-select-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import classnames from 'classnames';
 import React, { JSX } from 'react';
 
@@ -11,14 +11,14 @@ import React, { JSX } from 'react';
 import { NoOptionsMessage } from './no-options-message';
 
 export function SingularSelectControl(
-	props: EntitiesSearch.SingularControl< string > & {
+	props: Kensaku.SingularControl< string > & {
 		className?: string;
 	}
 ): JSX.Element {
 	const className = classnames(
 		props.className,
-		'wes-select-control',
-		'wes-select-control--singular'
+		'kensaku-select-control',
+		'kensaku-select-control--singular'
 	);
 
 	if ( props.options.length() <= 0 ) {
@@ -47,7 +47,7 @@ export function SingularSelectControl(
 			{ props.options.map( ( option ) => (
 				<option
 					key={ option.value }
-					className={ `wes-select-control-item wes-select-control-item--${ option.value }` }
+					className={ `kensaku-select-control-item kensaku-select-control-item--${ option.value }` }
 					value={ option.value }
 				>
 					{ option.label }

--- a/sources/client/src/components/toggle-control.tsx
+++ b/sources/client/src/components/toggle-control.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import classnames from 'classnames';
 import React, { JSX } from 'react';
 
@@ -11,17 +11,17 @@ import React, { JSX } from 'react';
 import { useId } from '../hooks/use-id';
 import { NoOptionsMessage } from './no-options-message';
 
-interface Option< V > extends EntitiesSearch.ControlOption< V > {
-	readonly selectedValues: EntitiesSearch.BaseControl< V >[ 'value' ];
+interface Option< V > extends Kensaku.ControlOption< V > {
+	readonly selectedValues: Kensaku.BaseControl< V >[ 'value' ];
 	readonly onChange: ( event: React.ChangeEvent< HTMLInputElement > ) => void;
 }
 
 export function ToggleControl(
-	props: EntitiesSearch.BaseControl< EntitiesSearch.Value > & {
+	props: Kensaku.BaseControl< Kensaku.Value > & {
 		className?: string;
 	}
 ): JSX.Element {
-	const className = classnames( props.className, 'wes-toggle-control' );
+	const className = classnames( props.className, 'kensaku-toggle-control' );
 
 	if ( props.options.length() <= 0 ) {
 		return <NoOptionsMessage />;
@@ -48,7 +48,7 @@ export function ToggleControl(
 	return (
 		<div className={ className }>
 			{ props.options.map( ( option ) => (
-				<Option< EntitiesSearch.Value >
+				<Option< Kensaku.Value >
 					key={ option.value }
 					label={ option.label }
 					value={ option.value }
@@ -66,13 +66,13 @@ function Option< V >( props: Option< V > ): JSX.Element {
 
 	return (
 		<div
-			className={ `wes-toggle-control-item wes-toggle-control-item--${ value }` }
+			className={ `kensaku-toggle-control-item kensaku-toggle-control-item--${ value }` }
 		>
 			<label htmlFor={ id }>
 				<input
 					type="checkbox"
 					id={ id }
-					className={ `wes-toggle-control-item__input-${ value }` }
+					className={ `kensaku-toggle-control-item__input-${ value }` }
 					checked={ props.selectedValues?.has( props.value ) }
 					value={ value }
 					onChange={ props.onChange }

--- a/sources/client/src/hooks/use-entities-options-storage.ts
+++ b/sources/client/src/hooks/use-entities-options-storage.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import { Reducer, Dispatch, useReducer, useEffect } from 'react';
 
 /**
@@ -17,8 +17,8 @@ import { reducer } from '../storage/entities/reducer';
 import { Set } from '../models/set';
 
 type _Reducer< E, K > = Reducer<
-	EntitiesSearch.EntitiesState< E, K >,
-	EntitiesSearch.StoreAction< E, K >
+	Kensaku.EntitiesState< E, K >,
+	Kensaku.StoreAction< E, K >
 >;
 
 /**
@@ -28,14 +28,14 @@ type _Reducer< E, K > = Reducer<
  */
 export function useEntitiesOptionsStorage< E, K >(
 	initialState: Pick<
-		EntitiesSearch.EntitiesState< E, K >,
+		Kensaku.EntitiesState< E, K >,
 		'entities' | 'kind'
 	>,
-	searchEntities: EntitiesSearch.SearchEntitiesFunction< E, K >
+	searchEntities: Kensaku.SearchEntitiesFunction< E, K >
 ): Readonly<
 	[
-		EntitiesSearch.EntitiesState< E, K >,
-		Dispatch< EntitiesSearch.StoreAction< E, K > >,
+		Kensaku.EntitiesState< E, K >,
+		Dispatch< Kensaku.StoreAction< E, K > >,
 	]
 > {
 	const [ state, dispatch ] = useReducer< _Reducer< E, K > >(
@@ -70,7 +70,7 @@ export function useEntitiesOptionsStorage< E, K >(
 			} )
 			.catch( ( error ) => {
 				doAction(
-					'wp-entities-search.on-storage-initialization.error',
+					'kensaku.on-storage-initialization.error',
 					error
 				);
 			} );

--- a/sources/client/src/hooks/use-entities-options-storage.ts
+++ b/sources/client/src/hooks/use-entities-options-storage.ts
@@ -27,16 +27,10 @@ type _Reducer< E, K > = Reducer<
  * @param searchEntities The function that will search the entities
  */
 export function useEntitiesOptionsStorage< E, K >(
-	initialState: Pick<
-		Kensaku.EntitiesState< E, K >,
-		'entities' | 'kind'
-	>,
+	initialState: Pick< Kensaku.EntitiesState< E, K >, 'entities' | 'kind' >,
 	searchEntities: Kensaku.SearchEntitiesFunction< E, K >
 ): Readonly<
-	[
-		Kensaku.EntitiesState< E, K >,
-		Dispatch< Kensaku.StoreAction< E, K > >,
-	]
+	[ Kensaku.EntitiesState< E, K >, Dispatch< Kensaku.StoreAction< E, K > > ]
 > {
 	const [ state, dispatch ] = useReducer< _Reducer< E, K > >(
 		reducer,
@@ -69,10 +63,7 @@ export function useEntitiesOptionsStorage< E, K >(
 				} );
 			} )
 			.catch( ( error ) => {
-				doAction(
-					'kensaku.on-storage-initialization.error',
-					error
-				);
+				doAction( 'kensaku.on-storage-initialization.error', error );
 			} );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );

--- a/sources/client/src/hooks/use-entity-records.ts
+++ b/sources/client/src/hooks/use-entity-records.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * WordPress dependencies
@@ -33,7 +33,7 @@ export function useEntityRecords< Entity >(
 	kind: string,
 	name: string,
 	queryArgs: Record< string, unknown > = {}
-): EntitiesSearch.EntitiesRecords< Entity > {
+): Kensaku.EntitiesRecords< Entity > {
 	const entities = useCoreEntityRecords< Entity >( kind, name, queryArgs );
 	const status = entities.status as any as ResolveStatus;
 

--- a/sources/client/src/hooks/use-query-viewable-post-types.ts
+++ b/sources/client/src/hooks/use-query-viewable-post-types.ts
@@ -16,9 +16,11 @@ import { useEntityRecords } from './use-entity-records';
  * @public
  */
 export function useQueryViewablePostTypes(): Kensaku.EntitiesRecords< Kensaku.ViewablePostType > {
-	const entitiesRecords = useEntityRecords<
-		Kensaku.PostType< 'edit' >
-	>( 'root', 'postType', { per_page: -1 } );
+	const entitiesRecords = useEntityRecords< Kensaku.PostType< 'edit' > >(
+		'root',
+		'postType',
+		{ per_page: -1 }
+	);
 
 	const viewablePostTypes = entitiesRecords
 		.records()

--- a/sources/client/src/hooks/use-query-viewable-post-types.ts
+++ b/sources/client/src/hooks/use-query-viewable-post-types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -15,16 +15,16 @@ import { useEntityRecords } from './use-entity-records';
  *
  * @public
  */
-export function useQueryViewablePostTypes(): EntitiesSearch.EntitiesRecords< EntitiesSearch.ViewablePostType > {
+export function useQueryViewablePostTypes(): Kensaku.EntitiesRecords< Kensaku.ViewablePostType > {
 	const entitiesRecords = useEntityRecords<
-		EntitiesSearch.PostType< 'edit' >
+		Kensaku.PostType< 'edit' >
 	>( 'root', 'postType', { per_page: -1 } );
 
 	const viewablePostTypes = entitiesRecords
 		.records()
 		.filter(
 			( postType ) => postType.viewable
-		) as Set< EntitiesSearch.ViewablePostType >;
+		) as Set< Kensaku.ViewablePostType >;
 
 	return {
 		...entitiesRecords,

--- a/sources/client/src/hooks/use-query-viewable-taxonomies.ts
+++ b/sources/client/src/hooks/use-query-viewable-taxonomies.ts
@@ -16,9 +16,11 @@ import { useEntityRecords } from './use-entity-records';
  * @public
  */
 export function useQueryViewableTaxonomies(): Kensaku.EntitiesRecords< Kensaku.ViewableTaxonomy > {
-	const entitiesRecords = useEntityRecords<
-		Kensaku.Taxonomy< 'edit' >
-	>( 'root', 'taxonomy', { per_page: -1 } );
+	const entitiesRecords = useEntityRecords< Kensaku.Taxonomy< 'edit' > >(
+		'root',
+		'taxonomy',
+		{ per_page: -1 }
+	);
 
 	const viewableTaxonomies = entitiesRecords
 		.records()

--- a/sources/client/src/hooks/use-query-viewable-taxonomies.ts
+++ b/sources/client/src/hooks/use-query-viewable-taxonomies.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -15,16 +15,16 @@ import { useEntityRecords } from './use-entity-records';
  *
  * @public
  */
-export function useQueryViewableTaxonomies(): EntitiesSearch.EntitiesRecords< EntitiesSearch.ViewableTaxonomy > {
+export function useQueryViewableTaxonomies(): Kensaku.EntitiesRecords< Kensaku.ViewableTaxonomy > {
 	const entitiesRecords = useEntityRecords<
-		EntitiesSearch.Taxonomy< 'edit' >
+		Kensaku.Taxonomy< 'edit' >
 	>( 'root', 'taxonomy', { per_page: -1 } );
 
 	const viewableTaxonomies = entitiesRecords
 		.records()
 		.filter(
 			( taxonomy ) => taxonomy.visibility.publicly_queryable
-		) as Set< EntitiesSearch.ViewableTaxonomy >;
+		) as Set< Kensaku.ViewableTaxonomy >;
 
 	return {
 		...entitiesRecords,

--- a/sources/client/src/hooks/use-search.ts
+++ b/sources/client/src/hooks/use-search.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 /**
@@ -16,7 +16,7 @@ import { doAction } from '@wordpress/hooks';
 import { Set } from '../models/set';
 
 type SearchPhrase = Parameters<
-	EntitiesSearch.SearchControl[ 'onChange' ]
+	Kensaku.SearchControl[ 'onChange' ]
 >[ 0 ];
 type SearchFunc = ( phrase: SearchPhrase ) => void;
 
@@ -30,10 +30,10 @@ type SearchFunc = ( phrase: SearchPhrase ) => void;
  * @param dispatch       The dispatch function to update the state
  */
 export function useSearch< E, K >(
-	searchEntities: EntitiesSearch.SearchEntitiesFunction< E, K >,
-	kind: EntitiesSearch.Kind< K >,
-	entities: EntitiesSearch.Entities< E >,
-	dispatch: React.Dispatch< EntitiesSearch.StoreAction< E, K > >
+	searchEntities: Kensaku.SearchEntitiesFunction< E, K >,
+	kind: Kensaku.Kind< K >,
+	entities: Kensaku.Entities< E >,
+	dispatch: React.Dispatch< Kensaku.StoreAction< E, K > >
 ): SearchFunc {
 	return useThrottle(
 		( phrase: SearchPhrase ) => {
@@ -49,9 +49,9 @@ export function useSearch< E, K >(
 					} )
 				)
 				.catch( ( error ) => {
-					doAction( 'wp-entities-search.on-search.error', error );
+					doAction( 'kensaku.on-search.error', error );
 					const emptySet = new Set<
-						EntitiesSearch.ControlOption< E >
+						Kensaku.ControlOption< E >
 					>();
 					dispatch( {
 						type: 'UPDATE_CURRENT_ENTITIES_OPTIONS',

--- a/sources/client/src/hooks/use-search.ts
+++ b/sources/client/src/hooks/use-search.ts
@@ -15,9 +15,7 @@ import { doAction } from '@wordpress/hooks';
  */
 import { Set } from '../models/set';
 
-type SearchPhrase = Parameters<
-	Kensaku.SearchControl[ 'onChange' ]
->[ 0 ];
+type SearchPhrase = Parameters< Kensaku.SearchControl[ 'onChange' ] >[ 0 ];
 type SearchFunc = ( phrase: SearchPhrase ) => void;
 
 /**
@@ -50,9 +48,7 @@ export function useSearch< E, K >(
 				)
 				.catch( ( error ) => {
 					doAction( 'kensaku.on-search.error', error );
-					const emptySet = new Set<
-						Kensaku.ControlOption< E >
-					>();
+					const emptySet = new Set< Kensaku.ControlOption< E > >();
 					dispatch( {
 						type: 'UPDATE_CURRENT_ENTITIES_OPTIONS',
 						currentEntitiesOptions: emptySet,

--- a/sources/client/src/logging/index.ts
+++ b/sources/client/src/logging/index.ts
@@ -39,14 +39,10 @@ addAction(
 	}
 );
 
-addAction(
-	'kensaku.on-search.error',
-	'kensaku/on-search.error',
-	( error ) => {
-		console.error(
-			`Composite Entities by Kind - on Search Entities: ${
-				error.message ?? error
-			}`
-		);
-	}
-);
+addAction( 'kensaku.on-search.error', 'kensaku/on-search.error', ( error ) => {
+	console.error(
+		`Composite Entities by Kind - on Search Entities: ${
+			error.message ?? error
+		}`
+	);
+} );

--- a/sources/client/src/logging/index.ts
+++ b/sources/client/src/logging/index.ts
@@ -6,8 +6,8 @@ import { addAction } from '@wordpress/hooks';
 /* eslint-disable no-console */
 
 addAction(
-	'wp-entities-search.on-change-entities.error',
-	'wp-entities-search/wp-on-change-entities.error',
+	'kensaku.on-change-entities.error',
+	'kensaku/wp-on-change-entities.error',
 	( error ) => {
 		console.error(
 			`Composite Entities by Kind - on Change Entities: ${
@@ -18,8 +18,8 @@ addAction(
 );
 
 addAction(
-	'wp-entities-search.on-change-kind.error',
-	'wp-entities-search/wp-on-change-entities.error',
+	'kensaku.on-change-kind.error',
+	'kensaku/wp-on-change-entities.error',
 	( error ) => {
 		console.error(
 			`Composite Entities by Kind - on Change Kind: ${
@@ -30,8 +30,8 @@ addAction(
 );
 
 addAction(
-	'wp-entities-search.on-storage-initialization.error',
-	'wp-entities-search/on-storage-initialization.error',
+	'kensaku.on-storage-initialization.error',
+	'kensaku/on-storage-initialization.error',
 	( error ) => {
 		console.error(
 			`Composite Entities by Kind: ${ error.message ?? error }`
@@ -40,8 +40,8 @@ addAction(
 );
 
 addAction(
-	'wp-entities-search.on-search.error',
-	'wp-entities-search/on-search.error',
+	'kensaku.on-search.error',
+	'kensaku/on-search.error',
 	( error ) => {
 		console.error(
 			`Composite Entities by Kind - on Search Entities: ${

--- a/sources/client/src/models/immutable-record.ts
+++ b/sources/client/src/models/immutable-record.ts
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
-export class ImmutableRecord< T > implements EntitiesSearch.Record< T > {
+export class ImmutableRecord< T > implements Kensaku.Record< T > {
 	readonly #map: Record< string, T > = {};
 
 	public constructor( map: Record< string, T > = {} ) {

--- a/sources/client/src/storage/entities/initial-state.ts
+++ b/sources/client/src/storage/entities/initial-state.ts
@@ -1,22 +1,22 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
  */
 import { Set } from '../../models/set';
 
-type Options< V > = EntitiesSearch.ControlOption< V >;
+type Options< V > = Kensaku.ControlOption< V >;
 
 /**
  * @internal
  * @param initialState The initial state to merge with the default state
  */
 export function makeInitialState< E, K >(
-	initialState: Partial< EntitiesSearch.EntitiesState< E, K > >
-): EntitiesSearch.EntitiesState< E, K > {
+	initialState: Partial< Kensaku.EntitiesState< E, K > >
+): Kensaku.EntitiesState< E, K > {
 	return {
 		entities: new Set< E >( [] ),
 		kind: new Set< K >( [] ),

--- a/sources/client/src/storage/entities/reducer.ts
+++ b/sources/client/src/storage/entities/reducer.ts
@@ -41,8 +41,7 @@ export function reducer< E, K >(
 				...state,
 				selectedEntitiesOptions: action.selectedEntitiesOptions,
 				entities: action.selectedEntitiesOptions.map(
-					( option: Kensaku.ControlOption< E > ) =>
-						option.value
+					( option: Kensaku.ControlOption< E > ) => option.value
 				),
 			};
 

--- a/sources/client/src/storage/entities/reducer.ts
+++ b/sources/client/src/storage/entities/reducer.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -14,9 +14,9 @@ import { Set } from '../../models/set';
  * @param action The action to be performed
  */
 export function reducer< E, K >(
-	state: EntitiesSearch.EntitiesState< E, K >,
-	action: EntitiesSearch.StoreAction< E, K >
-): EntitiesSearch.EntitiesState< E, K > {
+	state: Kensaku.EntitiesState< E, K >,
+	action: Kensaku.StoreAction< E, K >
+): Kensaku.EntitiesState< E, K > {
 	switch ( action.type ) {
 		case 'UPDATE_ENTITIES':
 			return {
@@ -41,7 +41,7 @@ export function reducer< E, K >(
 				...state,
 				selectedEntitiesOptions: action.selectedEntitiesOptions,
 				entities: action.selectedEntitiesOptions.map(
-					( option: EntitiesSearch.ControlOption< E > ) =>
+					( option: Kensaku.ControlOption< E > ) =>
 						option.value
 				),
 			};

--- a/sources/client/src/utils/convert-entities-to-control-options.ts
+++ b/sources/client/src/utils/convert-entities-to-control-options.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -19,7 +19,7 @@ export function convertEntitiesToControlOptions<
 	labelKey: string,
 	valueKey: string,
 	...extraKeys: ReadonlyArray< string >
-): Set< EntitiesSearch.ControlOption< V > > {
+): Set< Kensaku.ControlOption< V > > {
 	return entities.map( ( entity ) => {
 		const label = entity[ labelKey ];
 		const value = entity[ valueKey ];

--- a/sources/client/src/utils/is-control-option.ts
+++ b/sources/client/src/utils/is-control-option.ts
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 export function isControlOption(
 	option: unknown
-): option is EntitiesSearch.ControlOption< any > {
+): option is Kensaku.ControlOption< any > {
 	if ( option === null ) {
 		return false;
 	}

--- a/sources/client/src/utils/order-selected-options-at-the-top.ts
+++ b/sources/client/src/utils/order-selected-options-at-the-top.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -9,9 +9,9 @@ import EntitiesSearch from '@types';
 import { Set } from '../models/set';
 
 export function orderSelectedOptionsAtTheTop< V >(
-	options: Set< EntitiesSearch.ControlOption< V > >,
+	options: Set< Kensaku.ControlOption< V > >,
 	collection: Set< V > | undefined
-): Set< EntitiesSearch.ControlOption< V > > {
+): Set< Kensaku.ControlOption< V > > {
 	if ( options.length() <= 0 ) {
 		return options;
 	}
@@ -19,8 +19,8 @@ export function orderSelectedOptionsAtTheTop< V >(
 		return options;
 	}
 
-	let _collection = new Set< EntitiesSearch.ControlOption< V > >();
-	let _options = new Set< EntitiesSearch.ControlOption< V > >();
+	let _collection = new Set< Kensaku.ControlOption< V > >();
+	let _options = new Set< Kensaku.ControlOption< V > >();
 
 	options.forEach( ( option ) => {
 		if ( collection.has( option.value ) ) {

--- a/sources/client/src/utils/unique-control-options.ts
+++ b/sources/client/src/utils/unique-control-options.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -10,10 +10,10 @@ import { Set } from '../models/set';
 
 // TODO Is this necessary due the new Set implementation?
 export function uniqueControlOptions< V >(
-	set: Set< EntitiesSearch.ControlOption< V > >
-): Set< EntitiesSearch.ControlOption< V > > {
-	let uniqueOptions = new Set< EntitiesSearch.ControlOption< V > >();
-	const temp: Array< EntitiesSearch.ControlOption< V >[ 'value' ] > = [];
+	set: Set< Kensaku.ControlOption< V > >
+): Set< Kensaku.ControlOption< V > > {
+	let uniqueOptions = new Set< Kensaku.ControlOption< V > >();
+	const temp: Array< Kensaku.ControlOption< V >[ 'value' ] > = [];
 
 	for ( const option of set ) {
 		if ( ! temp.includes( option.value ) ) {

--- a/sources/client/src/value-objects/control-option.ts
+++ b/sources/client/src/value-objects/control-option.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 /**
  * Internal dependencies
@@ -10,16 +10,16 @@ import { assert } from '../utils/assert';
 import { ImmutableRecord } from '../models/immutable-record';
 
 export class ControlOption< V >
-	implements EntitiesSearch.EnrichedControlOption< V >
+	implements Kensaku.EnrichedControlOption< V >
 {
 	public readonly label: string;
 	public readonly value: V;
-	public readonly extra: EntitiesSearch.Record< unknown >;
+	public readonly extra: Kensaku.Record< unknown >;
 
 	public constructor(
 		label: string,
 		value: V,
-		extra: EntitiesSearch.Record< unknown > = new ImmutableRecord()
+		extra: Kensaku.Record< unknown > = new ImmutableRecord()
 	) {
 		assert(
 			label !== '',

--- a/sources/client/src/value-objects/control-option.ts
+++ b/sources/client/src/value-objects/control-option.ts
@@ -9,9 +9,7 @@ import Kensaku from '@types';
 import { assert } from '../utils/assert';
 import { ImmutableRecord } from '../models/immutable-record';
 
-export class ControlOption< V >
-	implements Kensaku.EnrichedControlOption< V >
-{
+export class ControlOption< V > implements Kensaku.EnrichedControlOption< V > {
 	public readonly label: string;
 	public readonly value: V;
 	public readonly extra: Kensaku.Record< unknown >;

--- a/sources/server/src/Library.php
+++ b/sources/server/src/Library.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SpaghettiDojo\Wp\EntitiesSearch;
+namespace SpaghettiDojo\Kensaku;
 
 use Inpsyde\Modularity;
 

--- a/sources/server/src/Modules/BlockEditor/Module.php
+++ b/sources/server/src/Modules/BlockEditor/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SpaghettiDojo\Wp\EntitiesSearch\Modules\BlockEditor;
+namespace SpaghettiDojo\Kensaku\Modules\BlockEditor;
 
 use Inpsyde\Modularity;
 use Psr\Container;
@@ -37,11 +37,11 @@ class Module implements Modularity\Module\ExecutableModule
              */
             $asset = (array)include "{$baseDir}/build/main.asset.php";
             $dependencies = (array)($asset['dependencies'] ?? null);
-            self::isInDebugMode() and $dependencies[] = 'wp-entities-search-logging';
+            self::isInDebugMode() and $dependencies[] = 'kensaku-logging';
             $version = (string)($asset['version'] ?? null) ?: false;
 
             \wp_register_script(
-                'wp-entities-search',
+                'kensaku',
                 "{$baseUrl}/build/main.js",
                 $dependencies,
                 $version,

--- a/sources/server/src/Modules/E2e/Module.php
+++ b/sources/server/src/Modules/E2e/Module.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace SpaghettiDojo\Wp\EntitiesSearch\Modules\E2e;
+namespace SpaghettiDojo\Kensaku\Modules\E2e;
 
 use Inpsyde\Modularity;
 use Psr\Container;
 
 /**
- * @internal \SpaghettiDojo\Wp\EntitiesSearch
+ * @internal \SpaghettiDojo\Kensaku
  */
 class Module implements Modularity\Module\ExecutableModule
 {
@@ -79,17 +79,17 @@ class Module implements Modularity\Module\ExecutableModule
         $baseUrl = \untrailingslashit($properties->baseUrl());
 
         \wp_register_script(
-            'wp-entities-search-e2e-post-types-example-block',
+            'kensaku-e2e-post-types-example-block',
             "{$baseUrl}/sources/server/src/Modules/E2e/resources/js/post-types-example-block/index.js",
-            ['wp-entities-search'],
+            ['kensaku'],
             '0.0.0',
             true,
         );
 
         \wp_register_script(
-            'wp-entities-search-e2e-taxonomies-example-block',
+            'kensaku-e2e-taxonomies-example-block',
             "{$baseUrl}/sources/server/src/Modules/E2e/resources/js/taxonomies-example-block/index.js",
-            ['wp-entities-search'],
+            ['kensaku'],
             '0.0.0',
             true,
         );

--- a/sources/server/src/Modules/E2e/resources/js/post-types-example-block/block.json
+++ b/sources/server/src/Modules/E2e/resources/js/post-types-example-block/block.json
@@ -1,10 +1,10 @@
 {
 	"apiVersion": 3,
 	"title": "Post Types Example Block",
-	"name": "wp-entities-search/post-types-example-block",
+	"name": "kensaku/post-types-example-block",
 	"category": "uncategorized",
 	"icon": "wordpress",
-	"editorScript": "wp-entities-search-e2e-post-types-example-block",
+	"editorScript": "kensaku-e2e-post-types-example-block",
 	"attributes": {
 		"postType": {
 			"type": "array",

--- a/sources/server/src/Modules/E2e/resources/js/post-types-example-block/index.js
+++ b/sources/server/src/Modules/E2e/resources/js/post-types-example-block/index.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
 	const UNSUPPORTED_CPTS = ['attachment'];
 
-	const { wp, wpEntitiesSearch } = window;
+	const { wp, kensaku } = window;
 
 	const { createElement } = wp.element;
 	const { registerBlockType } = wp.blocks;
@@ -21,18 +21,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		useQueryViewablePostTypes,
 		convertEntitiesToControlOptions,
 		createSearchEntitiesOptions,
-	} = wpEntitiesSearch;
+	} = kensaku;
 
 	// TODO Check why the object form does not work.
-	registerBlockType('wp-entities-search/post-types-example-block', {
+	registerBlockType('kensaku/post-types-example-block', {
 		apiVersion: 2,
 		title: 'Post Types Example Block',
 		category: 'uncategorized',
 		icon: 'wordpress',
-		editorScript: 'wp-entities-search-e2e-post-types-example-block',
+		editorScript: 'kensaku-e2e-post-types-example-block',
 		edit: function Edit(props) {
 			const blockProps = useBlockProps({
-				className: 'wp-entities-search-e2e-post-types-example-block',
+				className: 'kensaku-e2e-post-types-example-block',
 			});
 
 			const postTypesEntities = useQueryViewablePostTypes();

--- a/sources/server/src/Modules/E2e/resources/js/taxonomies-example-block/block.json
+++ b/sources/server/src/Modules/E2e/resources/js/taxonomies-example-block/block.json
@@ -1,10 +1,10 @@
 {
 	"apiVersion": 3,
 	"title": "Taxonomies Example Block",
-	"name": "wp-entities-search/taxonomies-example-block",
+	"name": "kensaku/taxonomies-example-block",
 	"category": "uncategorized",
 	"icon": "wordpress",
-	"editorScript": "wp-entities-search-e2e-taxonomies-example-block",
+	"editorScript": "kensaku-e2e-taxonomies-example-block",
 	"attributes": {
 		"taxonomy": {
 			"type": "array",

--- a/sources/server/src/Modules/E2e/resources/js/taxonomies-example-block/index.js
+++ b/sources/server/src/Modules/E2e/resources/js/taxonomies-example-block/index.js
@@ -1,5 +1,5 @@
 document.addEventListener('DOMContentLoaded', () => {
-	const { wp, wpEntitiesSearch, Immutable } = window;
+	const { wp, kensaku, Immutable } = window;
 
 	const { createElement } = wp.element;
 	const { registerBlockType } = wp.blocks;
@@ -20,18 +20,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		useQueryViewableTaxonomies,
 		convertEntitiesToControlOptions,
 		createSearchEntitiesOptions,
-	} = wpEntitiesSearch;
+	} = kensaku;
 
 	// TODO Check why the object form does not work.
-	registerBlockType('wp-entities-search/taxonomies-example-block', {
+	registerBlockType('kensaku/taxonomies-example-block', {
 		apiVersion: 2,
 		title: 'Taxonomies Example Block',
 		category: 'uncategorized',
 		icon: 'wordpress',
-		editorScript: 'wp-entities-search-e2e-taxonomies-example-block',
+		editorScript: 'kensaku-e2e-taxonomies-example-block',
 		edit: function Edit(props) {
 			const blockProps = useBlockProps({
-				className: 'wp-entities-search-e2e-taxonomies-example-block',
+				className: 'kensaku-e2e-taxonomies-example-block',
 			});
 
 			const taxonomiesEntities = useQueryViewableTaxonomies();

--- a/sources/server/src/Modules/Logging/Module.php
+++ b/sources/server/src/Modules/Logging/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace SpaghettiDojo\Wp\EntitiesSearch\Modules\Logging;
+namespace SpaghettiDojo\Kensaku\Modules\Logging;
 
 use Inpsyde\Modularity;
 use Psr\Container;
@@ -44,7 +44,7 @@ class Module implements Modularity\Module\ExecutableModule
             $version = (string)($asset['version'] ?? null) ?: false;
 
             \wp_register_script(
-                'wp-entities-search-logging',
+                'kensaku-logging',
                 "{$baseUrl}/build/logging.js",
                 $dependencies,
                 $version,

--- a/tests/client/integration/components/__snapshots__/preset-posts-types.markup.test.tsx.snap
+++ b/tests/client/integration/components/__snapshots__/preset-posts-types.markup.test.tsx.snap
@@ -3,24 +3,24 @@
 exports[`Preset Entities By Kind Should render the CompositeEntitiesByKind component with the appropriate configuration 1`] = `
 <DocumentFragment>
   <div
-    class="wes-preset-entities-by-kind extra-class-name"
+    class="kensaku-preset-entities-by-kind extra-class-name"
   >
     <div>
       KindComponent
     </div>
     <div
-      class="wes-search-control"
+      class="kensaku-search-control"
     >
       <label
         for=":r0:"
       >
         <span
-          class="wes-search-control__label"
+          class="kensaku-search-control__label"
         >
           Search
         </span>
         <input
-          class="wes-search-control__input"
+          class="kensaku-search-control__input"
           id=":r0:"
           type="search"
           value=""

--- a/tests/client/integration/components/composite-entities-by-kind.test.tsx
+++ b/tests/client/integration/components/composite-entities-by-kind.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 import { describe, it, expect, jest } from '@jest/globals';
@@ -38,7 +38,7 @@ describe( 'CompositeEntitiesByKind', () => {
 			<CompositeEntitiesByKind
 				searchEntities={ () =>
 					Promise.resolve(
-						new Set< EntitiesSearch.ControlOption< any > >()
+						new Set< Kensaku.ControlOption< any > >()
 					)
 				}
 				entities={ {
@@ -97,7 +97,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					kind={ {
 						value: new Set( [ 'post' ] ),
 						options: new Set<
-							EntitiesSearch.ControlOption< any >
+							Kensaku.ControlOption< any >
 						>(),
 						onChange: () => {},
 					} }
@@ -179,7 +179,7 @@ describe( 'CompositeEntitiesByKind', () => {
 
 	it( 'Pass to the children the updated entities options when the kind change', async () => {
 		let expectedEntities = new Set<
-			EntitiesSearch.ControlOption< string >
+			Kensaku.ControlOption< string >
 		>();
 
 		const rendered = await act( () =>
@@ -311,7 +311,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		expect( expectedEntities.length() ).toBe( 0 );
 
 		expect( jest.mocked( doAction ) ).toHaveBeenCalledWith(
-			'wp-entities-search.on-change-kind.error',
+			'kensaku.on-change-kind.error',
 			'Error'
 		);
 	} );
@@ -326,7 +326,7 @@ describe( 'CompositeEntitiesByKind', () => {
 				] )
 			)
 		) as jest.Mock<
-			EntitiesSearch.SearchEntitiesFunction< string, string >
+			Kensaku.SearchEntitiesFunction< string, string >
 		>;
 
 		const rendered = await act( () =>
@@ -342,7 +342,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					kind={ {
 						value: new Set( [ 'post' ] ),
 						options: new Set<
-							EntitiesSearch.ControlOption< any >
+							Kensaku.ControlOption< any >
 						>(),
 						onChange: () => {},
 					} }
@@ -373,7 +373,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		const selectedEntities = new Set( [ '1', '2' ] );
 
 		const searchEntities = jest.fn() as jest.Mock<
-			EntitiesSearch.CompositeEntitiesKinds<
+			Kensaku.CompositeEntitiesKinds<
 				string,
 				string
 			>[ 'searchEntities' ]
@@ -390,7 +390,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					kind={ {
 						value: new Set( [ 'post' ] ),
 						options: new Set<
-							EntitiesSearch.ControlOption< any >
+							Kensaku.ControlOption< any >
 						>(),
 						onChange: () => {},
 					} }
@@ -425,7 +425,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					kind={ {
 						value: new Set( [ 'post' ] ),
 						options: new Set<
-							EntitiesSearch.ControlOption< any >
+							Kensaku.ControlOption< any >
 						>(),
 						onChange: () => {},
 					} }
@@ -438,7 +438,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		} );
 
 		expect( doAction ).toHaveBeenCalledWith(
-			'wp-entities-search.on-storage-initialization.error',
+			'kensaku.on-storage-initialization.error',
 			'Error'
 		);
 	} );
@@ -487,7 +487,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		await userEvent.selectOptions( entitiesSelect, [ 'post-1' ] );
 
 		expect( jest.mocked( doAction ) ).toHaveBeenCalledWith(
-			'wp-entities-search.on-change-entities.error',
+			'kensaku.on-change-entities.error',
 			'Error'
 		);
 	} );
@@ -499,7 +499,7 @@ describe( 'CompositeEntitiesByKind', () => {
 			<CompositeEntitiesByKind
 				searchEntities={ () =>
 					Promise.resolve(
-						new Set< EntitiesSearch.ControlOption< any > >()
+						new Set< Kensaku.ControlOption< any > >()
 					)
 				}
 				entities={ {

--- a/tests/client/integration/components/composite-entities-by-kind.test.tsx
+++ b/tests/client/integration/components/composite-entities-by-kind.test.tsx
@@ -37,9 +37,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		const rendered = render(
 			<CompositeEntitiesByKind
 				searchEntities={ () =>
-					Promise.resolve(
-						new Set< Kensaku.ControlOption< any > >()
-					)
+					Promise.resolve( new Set< Kensaku.ControlOption< any > >() )
 				}
 				entities={ {
 					value: new Set(),
@@ -96,9 +94,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					} }
 					kind={ {
 						value: new Set( [ 'post' ] ),
-						options: new Set<
-							Kensaku.ControlOption< any >
-						>(),
+						options: new Set< Kensaku.ControlOption< any > >(),
 						onChange: () => {},
 					} }
 				>
@@ -178,9 +174,7 @@ describe( 'CompositeEntitiesByKind', () => {
 	} );
 
 	it( 'Pass to the children the updated entities options when the kind change', async () => {
-		let expectedEntities = new Set<
-			Kensaku.ControlOption< string >
-		>();
+		let expectedEntities = new Set< Kensaku.ControlOption< string > >();
 
 		const rendered = await act( () =>
 			render(
@@ -325,9 +319,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					{ label: 'Post 2', value: 'post-2' },
 				] )
 			)
-		) as jest.Mock<
-			Kensaku.SearchEntitiesFunction< string, string >
-		>;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< string, string > >;
 
 		const rendered = await act( () =>
 			render(
@@ -341,9 +333,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					} }
 					kind={ {
 						value: new Set( [ 'post' ] ),
-						options: new Set<
-							Kensaku.ControlOption< any >
-						>(),
+						options: new Set< Kensaku.ControlOption< any > >(),
 						onChange: () => {},
 					} }
 				>
@@ -373,10 +363,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		const selectedEntities = new Set( [ '1', '2' ] );
 
 		const searchEntities = jest.fn() as jest.Mock<
-			Kensaku.CompositeEntitiesKinds<
-				string,
-				string
-			>[ 'searchEntities' ]
+			Kensaku.CompositeEntitiesKinds< string, string >[ 'searchEntities' ]
 		>;
 
 		await act( () =>
@@ -389,9 +376,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					} }
 					kind={ {
 						value: new Set( [ 'post' ] ),
-						options: new Set<
-							Kensaku.ControlOption< any >
-						>(),
+						options: new Set< Kensaku.ControlOption< any > >(),
 						onChange: () => {},
 					} }
 				>
@@ -424,9 +409,7 @@ describe( 'CompositeEntitiesByKind', () => {
 					} }
 					kind={ {
 						value: new Set( [ 'post' ] ),
-						options: new Set<
-							Kensaku.ControlOption< any >
-						>(),
+						options: new Set< Kensaku.ControlOption< any > >(),
 						onChange: () => {},
 					} }
 				>
@@ -498,9 +481,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		const rendered = render(
 			<CompositeEntitiesByKind
 				searchEntities={ () =>
-					Promise.resolve(
-						new Set< Kensaku.ControlOption< any > >()
-					)
+					Promise.resolve( new Set< Kensaku.ControlOption< any > >() )
 				}
 				entities={ {
 					value: new Set(),

--- a/tests/client/integration/components/composite-entities-by-kind.test.tsx
+++ b/tests/client/integration/components/composite-entities-by-kind.test.tsx
@@ -67,7 +67,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const kindSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		await userEvent.selectOptions( kindSelect, 'page' );
@@ -106,7 +106,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const entitiesSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		await userEvent.selectOptions( entitiesSelect, [ 'post-2' ] );
@@ -160,10 +160,10 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const kindSelect = rendered.container.querySelector(
-			'.wes-select-control--singular'
+			'.kensaku-select-control--singular'
 		) as HTMLSelectElement;
 		const entitiesSelect = rendered.container.querySelector(
-			'.wes-select-control--plural'
+			'.kensaku-select-control--plural'
 		) as HTMLSelectElement;
 
 		await userEvent.selectOptions( entitiesSelect, [ 'post-2' ] );
@@ -230,7 +230,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const kindSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		expect( expectedEntities.length() ).toBe( 2 );
@@ -298,7 +298,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const kindSelect = rendered.container.querySelector(
-			'.wes-select-control--singular'
+			'.kensaku-select-control--singular'
 		) as HTMLSelectElement;
 
 		await userEvent.selectOptions( kindSelect, 'page' );
@@ -345,7 +345,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const entitiesSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		expect( selectedEntities.length() ).toBe( 2 );
@@ -464,7 +464,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const entitiesSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		await userEvent.selectOptions( entitiesSelect, [ 'post-1' ] );
@@ -503,7 +503,7 @@ describe( 'CompositeEntitiesByKind', () => {
 		);
 
 		const postTypeSelect = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		await userEvent.deselectOptions( postTypeSelect, [ 'post' ] );

--- a/tests/client/integration/components/preset-posts-types.markup.test.tsx
+++ b/tests/client/integration/components/preset-posts-types.markup.test.tsx
@@ -66,7 +66,7 @@ describe( 'Preset Entities By Kind', () => {
 
 		const kindComponent = screen.getByTestId( 'kind-component' );
 		const firstComponent = rendered.container.querySelector(
-			'.wes-preset-entities-by-kind'
+			'.kensaku-preset-entities-by-kind'
 		);
 
 		expect( kindComponent === firstComponent?.firstElementChild ).toEqual(
@@ -101,7 +101,7 @@ describe( 'Preset Entities By Kind', () => {
 
 		const kindComponent = screen.getByTestId( 'entities-component' );
 		const firstComponent = rendered.container.querySelector(
-			'.wes-preset-entities-by-kind'
+			'.kensaku-preset-entities-by-kind'
 		);
 
 		expect( kindComponent === firstComponent?.lastElementChild ).toEqual(
@@ -137,7 +137,7 @@ describe( 'Preset Entities By Kind', () => {
 
 		expect(
 			rendered.container
-				.querySelector( '.wes-preset-entities-by-kind' )
+				.querySelector( '.kensaku-preset-entities-by-kind' )
 				?.classList.contains( 'extra-class' )
 		).toEqual( true );
 	} );

--- a/tests/client/unit/api/search-entities.test.ts
+++ b/tests/client/unit/api/search-entities.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it, jest } from '@jest/globals';
 
@@ -54,7 +54,7 @@ describe( 'Search Posts', () => {
 		// @ts-ignore
 		jest.mocked( fetch ).mockResolvedValue( expected );
 
-		const entities = await searchEntities< EntitiesSearch.Post >(
+		const entities = await searchEntities< Kensaku.Post >(
 			'post',
 			new Set( [ 'post' ] ),
 			'foo',
@@ -94,7 +94,7 @@ describe( 'Search Posts', () => {
 		// @ts-ignore
 		expect( expectedError.name ).toBe( 'AbortError' );
 		expect( doAction ).toHaveBeenCalledWith(
-			'wp-entities-search.on-search.abort',
+			'kensaku.on-search.abort',
 			// @ts-ignore
 			expectedError
 		);

--- a/tests/client/unit/api/search-posts.test.ts
+++ b/tests/client/unit/api/search-posts.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import { faker } from '@faker-js/faker';
 import { describe, it, expect, jest } from '@jest/globals';
 
@@ -95,7 +95,7 @@ describe( 'Search Entities Options', () => {
 	it( 'Expect to call searchEntities with the given parameters', async () => {
 		const postTypes = new Set( [ 'post' ] );
 		const phrase = 'Phrase';
-		const fields: EntitiesSearch.SearchQueryFields = [ 'title', 'id' ];
+		const fields: Kensaku.SearchQueryFields = [ 'title', 'id' ];
 		const queryArguments = {
 			fields,
 		};

--- a/tests/client/unit/components/__snapshots__/plural-select-control.test.tsx.snap
+++ b/tests/client/unit/components/__snapshots__/plural-select-control.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Posts Select Render the NoOptionsMessage component 1`] = `
 <DocumentFragment>
   <p
-    class="wes-no-option-message"
+    class="kensaku-no-option-message"
   >
     No options
   </p>

--- a/tests/client/unit/components/__snapshots__/radio-control.test.tsx.snap
+++ b/tests/client/unit/components/__snapshots__/radio-control.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`KindRadioControl renders the NoOptionsMessage when there are no options 1`] = `
 <div
-  class="test-class wes-radio-control"
+  class="test-class kensaku-radio-control"
 />
 `;
 

--- a/tests/client/unit/components/__snapshots__/search-control.test.tsx.snap
+++ b/tests/client/unit/components/__snapshots__/search-control.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchControl renders the input outside the label if the id prop is not passed 1`] = `
 <input
-  class="wes-search-control__input"
+  class="kensaku-search-control__input"
   id=":r1:"
   type="search"
   value=""
@@ -11,7 +11,7 @@ exports[`SearchControl renders the input outside the label if the id prop is not
 
 exports[`SearchControl renders the input within the label if the id prop is passed 1`] = `
 <input
-  class="wes-search-control__input"
+  class="kensaku-search-control__input"
   id="search"
   type="search"
   value=""

--- a/tests/client/unit/components/__snapshots__/toggle-control.test.tsx.snap
+++ b/tests/client/unit/components/__snapshots__/toggle-control.test.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`EntitiesToggleControl renders correctly 1`] = `
 <div
-  class="test-class wes-toggle-control"
+  class="test-class kensaku-toggle-control"
 >
   <div
-    class="wes-toggle-control-item wes-toggle-control-item--1"
+    class="kensaku-toggle-control-item kensaku-toggle-control-item--1"
   >
     <label
       for=":r0:"
     >
       <input
         checked=""
-        class="wes-toggle-control-item__input-1"
+        class="kensaku-toggle-control-item__input-1"
         id=":r0:"
         type="checkbox"
         value="1"
@@ -21,13 +21,13 @@ exports[`EntitiesToggleControl renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="wes-toggle-control-item wes-toggle-control-item--2"
+    class="kensaku-toggle-control-item kensaku-toggle-control-item--2"
   >
     <label
       for=":r1:"
     >
       <input
-        class="wes-toggle-control-item__input-2"
+        class="kensaku-toggle-control-item__input-2"
         id=":r1:"
         type="checkbox"
         value="2"
@@ -36,13 +36,13 @@ exports[`EntitiesToggleControl renders correctly 1`] = `
     </label>
   </div>
   <div
-    class="wes-toggle-control-item wes-toggle-control-item--3"
+    class="kensaku-toggle-control-item kensaku-toggle-control-item--3"
   >
     <label
       for=":r2:"
     >
       <input
-        class="wes-toggle-control-item__input-3"
+        class="kensaku-toggle-control-item__input-3"
         id=":r2:"
         type="checkbox"
         value="3"
@@ -55,7 +55,7 @@ exports[`EntitiesToggleControl renders correctly 1`] = `
 
 exports[`EntitiesToggleControl renders the NoOptionsMessage when there are no options 1`] = `
 <p
-  class="wes-no-option-message"
+  class="kensaku-no-option-message"
 >
   No options
 </p>

--- a/tests/client/unit/components/plural-select-control.test.tsx
+++ b/tests/client/unit/components/plural-select-control.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 import { describe, it, expect } from '@jest/globals';
@@ -20,11 +20,11 @@ import { buildOptions } from '../utils';
 
 describe( 'Posts Select', () => {
 	it( 'Call the given onChange handler', async () => {
-		const option: EntitiesSearch.ControlOption< string > = {
+		const option: Kensaku.ControlOption< string > = {
 			label: faker.word.words( 2 ),
 			value: faker.word.noun(),
 		};
-		const options = new Set< EntitiesSearch.ControlOption< string > >( [] )
+		const options = new Set< Kensaku.ControlOption< string > >( [] )
 			.add( option )
 			.concat( buildOptions() );
 
@@ -59,11 +59,11 @@ describe( 'Posts Select', () => {
 	} );
 
 	it( 'Deselect the options', async () => {
-		const option: EntitiesSearch.ControlOption< string > = {
+		const option: Kensaku.ControlOption< string > = {
 			label: faker.word.words( 2 ),
 			value: faker.word.noun(),
 		};
-		const options = new Set< EntitiesSearch.ControlOption< string > >( [] )
+		const options = new Set< Kensaku.ControlOption< string > >( [] )
 			.add( option )
 			.concat( buildOptions() );
 

--- a/tests/client/unit/components/plural-select-control.test.tsx
+++ b/tests/client/unit/components/plural-select-control.test.tsx
@@ -41,7 +41,7 @@ describe( 'Posts Select', () => {
 			String( options.last()?.value ),
 		];
 		const select = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		/*
@@ -80,7 +80,7 @@ describe( 'Posts Select', () => {
 			String( options.last()?.value ),
 		];
 		const select = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		/*

--- a/tests/client/unit/components/preset-posts-types.test.tsx
+++ b/tests/client/unit/components/preset-posts-types.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import React from 'react';
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import { describe, expect, it, jest } from '@jest/globals';
 import { render } from '@testing-library/react';
 
@@ -31,7 +31,7 @@ describe( 'Preset Entities by Kind', () => {
 				ReturnType< typeof createSearchEntitiesOptions< string > >
 			>();
 
-		const entitiesFields: EntitiesSearch.SearchQueryFields = [
+		const entitiesFields: Kensaku.SearchQueryFields = [
 			'post_content',
 			'post_excerpt',
 		];
@@ -56,8 +56,8 @@ describe( 'Preset Entities by Kind', () => {
 			// @ts-ignore
 			(
 				_phrase: string,
-				_kind: EntitiesSearch.Kind< string >,
-				queryArguments?: EntitiesSearch.QueryArguments
+				_kind: Kensaku.Kind< string >,
+				queryArguments?: Kensaku.QueryArguments
 			) => {
 				expect( queryArguments?.fields ).toEqual( [
 					'title',

--- a/tests/client/unit/components/radio-control.test.tsx
+++ b/tests/client/unit/components/radio-control.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 import { expect, jest, describe, it } from '@jest/globals';
@@ -35,7 +35,7 @@ describe( 'KindRadioControl', () => {
 	it( 'renders the NoOptionsMessage when there are no options', () => {
 		const props = {
 			className: 'test-class',
-			options: new Set< EntitiesSearch.ControlOption< any > >(),
+			options: new Set< Kensaku.ControlOption< any > >(),
 			value: 'option-one',
 			onChange: jest.fn(),
 		};

--- a/tests/client/unit/components/singular-select-control.test.tsx
+++ b/tests/client/unit/components/singular-select-control.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 import { describe, it, expect, jest } from '@jest/globals';
@@ -24,13 +24,13 @@ describe( 'Post Types Select', () => {
 	 * in the React Select component, so we mock it.
 	 */
 	it( 'call the given onChange handler', ( done ) => {
-		let expectedValue: EntitiesSearch.SingularControl< string >[ 'value' ] =
+		let expectedValue: Kensaku.SingularControl< string >[ 'value' ] =
 			'';
-		const option: EntitiesSearch.ControlOption< string > = {
+		const option: Kensaku.ControlOption< string > = {
 			label: faker.word.words( 2 ),
 			value: faker.word.noun(),
 		};
-		const options = new Set< EntitiesSearch.ControlOption< string > >()
+		const options = new Set< Kensaku.ControlOption< string > >()
 			.add( option )
 			.concat( buildOptions() );
 

--- a/tests/client/unit/components/singular-select-control.test.tsx
+++ b/tests/client/unit/components/singular-select-control.test.tsx
@@ -24,8 +24,7 @@ describe( 'Post Types Select', () => {
 	 * in the React Select component, so we mock it.
 	 */
 	it( 'call the given onChange handler', ( done ) => {
-		let expectedValue: Kensaku.SingularControl< string >[ 'value' ] =
-			'';
+		let expectedValue: Kensaku.SingularControl< string >[ 'value' ] = '';
 		const option: Kensaku.ControlOption< string > = {
 			label: faker.word.words( 2 ),
 			value: faker.word.noun(),

--- a/tests/client/unit/components/singular-select-control.test.tsx
+++ b/tests/client/unit/components/singular-select-control.test.tsx
@@ -42,7 +42,7 @@ describe( 'Post Types Select', () => {
 		);
 
 		const select = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		userEvent.selectOptions( select, option.value ).then( () => {
@@ -61,7 +61,7 @@ describe( 'Post Types Select', () => {
 		);
 
 		expect(
-			rendered.container.querySelector( '.wes-no-option-message' )
+			rendered.container.querySelector( '.kensaku-no-option-message' )
 		).toBeInTheDocument();
 	} );
 
@@ -83,11 +83,11 @@ describe( 'Post Types Select', () => {
 		const rendered = render( <SingularSelectControl { ...props } /> );
 
 		const select = rendered.container.querySelector(
-			'.wes-select-control'
+			'.kensaku-select-control'
 		) as HTMLSelectElement;
 
 		const option = select.querySelector(
-			'.wes-select-control-item--option-one'
+			'.kensaku-select-control-item--option-one'
 		) as HTMLOptionElement;
 		option.value = 'option-3';
 

--- a/tests/client/unit/components/toggle-control.test.tsx
+++ b/tests/client/unit/components/toggle-control.test.tsx
@@ -99,7 +99,7 @@ describe( 'EntitiesToggleControl', () => {
 		const rendered = render( <ToggleControl { ...props } /> );
 
 		const option = rendered.container.querySelector(
-			'.wes-toggle-control-item__input-option-one'
+			'.kensaku-toggle-control-item__input-option-one'
 		) as HTMLOptionElement;
 		option.value = 'option-3';
 

--- a/tests/client/unit/hooks/use-entities-options-storage.test.tsx
+++ b/tests/client/unit/hooks/use-entities-options-storage.test.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 import React from 'react';
 
 import { describe, expect, it, jest } from '@jest/globals';
@@ -37,7 +37,7 @@ describe( 'Use Posts Options Storage', () => {
 				] )
 			)
 		) as jest.Mock<
-			EntitiesSearch.SearchEntitiesFunction< number, string >
+			Kensaku.SearchEntitiesFunction< number, string >
 		>;
 
 		const Component = () => {
@@ -104,7 +104,7 @@ describe( 'Use Posts Options Storage', () => {
 				? Promise.resolve( selectedEntitiesOptions )
 				: Promise.resolve( currentEntitiesOptions );
 		} ) as jest.Mock<
-			EntitiesSearch.SearchEntitiesFunction< number, string >
+			Kensaku.SearchEntitiesFunction< number, string >
 		>;
 
 		const dispatch = jest.fn();
@@ -190,7 +190,7 @@ describe( 'Use Posts Options Storage', () => {
 				] )
 			)
 		) as jest.Mock<
-			EntitiesSearch.SearchEntitiesFunction< number, string >
+			Kensaku.SearchEntitiesFunction< number, string >
 		>;
 
 		const Component = () => {
@@ -218,7 +218,7 @@ describe( 'Use Posts Options Storage', () => {
 		} );
 	} );
 
-	it( 'Execute the action wp-entities-search.on-storage-initialization.error when there is an error on searchEntities', async () => {
+	it( 'Execute the action kensaku.on-storage-initialization.error when there is an error on searchEntities', async () => {
 		const kind = new Set( [ 'post' ] );
 		const entities = new Set( [ 1, 2, 3 ] );
 		const searchEntities = jest.fn( () =>
@@ -241,7 +241,7 @@ describe( 'Use Posts Options Storage', () => {
 		await act( () => render( <Component /> ) );
 
 		expect( doAction ).toHaveBeenCalledWith(
-			'wp-entities-search.on-storage-initialization.error',
+			'kensaku.on-storage-initialization.error',
 			'Search Entities Failed.'
 		);
 	} );

--- a/tests/client/unit/hooks/use-entities-options-storage.test.tsx
+++ b/tests/client/unit/hooks/use-entities-options-storage.test.tsx
@@ -36,9 +36,7 @@ describe( 'Use Posts Options Storage', () => {
 					},
 				] )
 			)
-		) as jest.Mock<
-			Kensaku.SearchEntitiesFunction< number, string >
-		>;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< number, string > >;
 
 		const Component = () => {
 			useEntitiesOptionsStorage< number, string >(
@@ -103,9 +101,7 @@ describe( 'Use Posts Options Storage', () => {
 			return options?.include
 				? Promise.resolve( selectedEntitiesOptions )
 				: Promise.resolve( currentEntitiesOptions );
-		} ) as jest.Mock<
-			Kensaku.SearchEntitiesFunction< number, string >
-		>;
+		} ) as jest.Mock< Kensaku.SearchEntitiesFunction< number, string > >;
 
 		const dispatch = jest.fn();
 		jest.spyOn( React, 'useReducer' ).mockImplementation( ( _, state ) => [
@@ -189,9 +185,7 @@ describe( 'Use Posts Options Storage', () => {
 					},
 				] )
 			)
-		) as jest.Mock<
-			Kensaku.SearchEntitiesFunction< number, string >
-		>;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< number, string > >;
 
 		const Component = () => {
 			useEntitiesOptionsStorage< number, string >(

--- a/tests/client/unit/hooks/use-entity-records.test.ts
+++ b/tests/client/unit/hooks/use-entity-records.test.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { fromPartial } from '@total-typescript/shoehorn';
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, it, jest, expect } from '@jest/globals';
 
@@ -27,10 +27,10 @@ describe( 'useEntityRecords', () => {
 	 */
 	it( 'return set of records and succeed', () => {
 		const records = [
-			fromPartial< EntitiesSearch.PostType< 'edit' > >( {
+			fromPartial< Kensaku.PostType< 'edit' > >( {
 				name: 'foo',
 			} ),
-			fromPartial< EntitiesSearch.PostType< 'edit' > >( {
+			fromPartial< Kensaku.PostType< 'edit' > >( {
 				name: 'foo-3',
 			} ),
 		];
@@ -43,7 +43,7 @@ describe( 'useEntityRecords', () => {
 			status: 'SUCCESS',
 		} );
 
-		const result = useEntityRecords< EntitiesSearch.PostType< 'edit' > >(
+		const result = useEntityRecords< Kensaku.PostType< 'edit' > >(
 			'root',
 			'postType'
 		);
@@ -70,7 +70,7 @@ describe( 'useEntityRecords', () => {
 			status: 'RESOLVING',
 		} );
 
-		const result = useEntityRecords< EntitiesSearch.PostType< 'edit' > >(
+		const result = useEntityRecords< Kensaku.PostType< 'edit' > >(
 			'root',
 			'postType'
 		);
@@ -93,7 +93,7 @@ describe( 'useEntityRecords', () => {
 			status: 'ERROR',
 		} );
 
-		const result = useEntityRecords< EntitiesSearch.PostType< 'edit' > >(
+		const result = useEntityRecords< Kensaku.PostType< 'edit' > >(
 			'root',
 			'postType'
 		);
@@ -115,7 +115,7 @@ describe( 'useEntityRecords', () => {
 			status: 'RESOLVING',
 		} );
 
-		const result = useEntityRecords< EntitiesSearch.PostType< 'edit' > >(
+		const result = useEntityRecords< Kensaku.PostType< 'edit' > >(
 			'root',
 			'postType'
 		);

--- a/tests/client/unit/hooks/use-query-viewable-post-types.test.ts
+++ b/tests/client/unit/hooks/use-query-viewable-post-types.test.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { fromPartial } from '@total-typescript/shoehorn';
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, it, jest, expect } from '@jest/globals';
 
@@ -32,11 +32,11 @@ describe( 'Post Types Query', () => {
 			succeed: () => true,
 			records: () =>
 				new Set( [
-					fromPartial< EntitiesSearch.PostType< 'edit' > >( {
+					fromPartial< Kensaku.PostType< 'edit' > >( {
 						slug: 'viewable-post-type',
 						viewable: true,
 					} ),
-					fromPartial< EntitiesSearch.PostType< 'edit' > >( {
+					fromPartial< Kensaku.PostType< 'edit' > >( {
 						slug: 'not-viewable-post-type',
 						viewable: false,
 					} ),

--- a/tests/client/unit/hooks/use-query-viewable-taxonomies.test.ts
+++ b/tests/client/unit/hooks/use-query-viewable-taxonomies.test.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { fromPartial } from '@total-typescript/shoehorn';
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it, jest } from '@jest/globals';
 
@@ -27,19 +27,19 @@ describe( 'useQueryViewableTaxonomies', () => {
 			succeed: () => true,
 			records: () =>
 				new Set( [
-					fromPartial< EntitiesSearch.Taxonomy< 'edit' > >( {
+					fromPartial< Kensaku.Taxonomy< 'edit' > >( {
 						name: 'Category',
 						visibility: {
 							publicly_queryable: true,
 						},
 					} ),
-					fromPartial< EntitiesSearch.Taxonomy< 'edit' > >( {
+					fromPartial< Kensaku.Taxonomy< 'edit' > >( {
 						name: 'Tag',
 						visibility: {
 							publicly_queryable: true,
 						},
 					} ),
-					fromPartial< EntitiesSearch.Taxonomy< 'edit' > >( {
+					fromPartial< Kensaku.Taxonomy< 'edit' > >( {
 						name: 'Author',
 						visibility: {
 							publicly_queryable: false,

--- a/tests/client/unit/hooks/use-search.test.ts
+++ b/tests/client/unit/hooks/use-search.test.ts
@@ -7,7 +7,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { expect, it, describe, beforeEach, jest } from '@jest/globals';
 
@@ -39,7 +39,7 @@ describe( 'useSearch', () => {
 	it( 'Should update the search phrase', async () => {
 		const searchEntities = jest.fn( () =>
 			Promise.resolve( new Set( [ { label: 'Label', value: 1 } ] ) )
-		) as jest.Mock< EntitiesSearch.SearchEntitiesFunction< any, any > >;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< any, any > >;
 		const kind = new Set( [ 'post' ] );
 		const entities = new Set< number >();
 		const dispatch = jest.fn();
@@ -61,7 +61,7 @@ describe( 'useSearch', () => {
 	it( 'Should search the entities', () => {
 		const searchEntities = jest.fn( () =>
 			Promise.resolve( new Set( [ { label: 'Label', value: 1 } ] ) )
-		) as jest.Mock< EntitiesSearch.SearchEntitiesFunction< any, any > >;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< any, any > >;
 		const kind = new Set( [ 'post' ] );
 		const entities = new Set< number >();
 		const dispatch = jest.fn();
@@ -83,7 +83,7 @@ describe( 'useSearch', () => {
 	it( 'Should update the current entities options', async () => {
 		const searchEntities = jest.fn( () =>
 			Promise.resolve( new Set( [ { label: 'Label', value: 1 } ] ) )
-		) as jest.Mock< EntitiesSearch.SearchEntitiesFunction< any, any > >;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< any, any > >;
 		const kind = new Set( [ 'post' ] );
 		const entities = new Set< number >();
 		const dispatch = jest.fn();
@@ -127,7 +127,7 @@ describe( 'useSearch', () => {
 	it( 'Should update the current entities options with an empty set when an error occurs', async () => {
 		const searchEntities = jest.fn( () =>
 			Promise.resolve( new Set( [ { label: 'Label', value: 1 } ] ) )
-		) as jest.Mock< EntitiesSearch.SearchEntitiesFunction< any, any > >;
+		) as jest.Mock< Kensaku.SearchEntitiesFunction< any, any > >;
 		const kind = new Set( [ 'post' ] );
 		const entities = new Set< number >();
 		const dispatch = jest.fn();
@@ -144,7 +144,7 @@ describe( 'useSearch', () => {
 
 		expect( jest.mocked( doAction ) ).toHaveBeenCalledTimes( 1 );
 		expect( jest.mocked( doAction ) ).toHaveBeenCalledWith(
-			'wp-entities-search.on-search.error',
+			'kensaku.on-search.error',
 			new Error( 'Error' )
 		);
 	} );

--- a/tests/client/unit/storage/reducer.test.ts
+++ b/tests/client/unit/storage/reducer.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it } from '@jest/globals';
 
@@ -13,7 +13,7 @@ import { faker } from '@faker-js/faker';
 import { reducer } from '../../../../sources/client/src/storage/entities/reducer';
 import { Set } from '../../../../sources/client/src/models/set';
 
-let state: EntitiesSearch.EntitiesState< number, string >;
+let state: Kensaku.EntitiesState< number, string >;
 
 describe( 'reducer', () => {
 	it( 'Update the Entities', () => {

--- a/tests/client/unit/utils.ts
+++ b/tests/client/unit/utils.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { faker } from '@faker-js/faker';
 
@@ -10,8 +10,8 @@ import { faker } from '@faker-js/faker';
  */
 import { Set } from '../../../sources/client/src/models/set';
 
-export function buildOptions(): Set< EntitiesSearch.ControlOption< string > > {
-	let options = new Set< EntitiesSearch.ControlOption< string > >();
+export function buildOptions(): Set< Kensaku.ControlOption< string > > {
+	let options = new Set< Kensaku.ControlOption< string > >();
 
 	for ( let count = 0; count < 9; ++count ) {
 		options = options.add( {

--- a/tests/client/unit/utils/convert-entities-to-control-options.test.ts
+++ b/tests/client/unit/utils/convert-entities-to-control-options.test.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { fromPartial } from '@total-typescript/shoehorn';
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it } from '@jest/globals';
 
@@ -14,7 +14,7 @@ import { faker } from '@faker-js/faker';
 import { convertEntitiesToControlOptions } from '../../../../sources/client/src/utils/convert-entities-to-control-options';
 import { Set } from '../../../../sources/client/src/models/set';
 
-type ExtendedSearchEntityFields = EntitiesSearch.SearchEntityFields & {
+type ExtendedSearchEntityFields = Kensaku.SearchEntityFields & {
 	type: string;
 	excerpt: string;
 };

--- a/tests/client/unit/utils/ordered-selected-options-at-the-top.test.ts
+++ b/tests/client/unit/utils/ordered-selected-options-at-the-top.test.ts
@@ -17,9 +17,7 @@ describe( 'Ordered Selected Options at the Top', () => {
 	/*
 	 * Given options are always re-ordered to includes the given collection values at the top
 	 */
-	function generateOptions(): Array<
-		Kensaku.ControlOption< string >
-	> {
+	function generateOptions(): Array< Kensaku.ControlOption< string > > {
 		const options: Array< Kensaku.ControlOption< string > > = [];
 
 		for ( let i = 1; i <= 10; i++ ) {

--- a/tests/client/unit/utils/ordered-selected-options-at-the-top.test.ts
+++ b/tests/client/unit/utils/ordered-selected-options-at-the-top.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it } from '@jest/globals';
 
@@ -18,9 +18,9 @@ describe( 'Ordered Selected Options at the Top', () => {
 	 * Given options are always re-ordered to includes the given collection values at the top
 	 */
 	function generateOptions(): Array<
-		EntitiesSearch.ControlOption< string >
+		Kensaku.ControlOption< string >
 	> {
-		const options: Array< EntitiesSearch.ControlOption< string > > = [];
+		const options: Array< Kensaku.ControlOption< string > > = [];
 
 		for ( let i = 1; i <= 10; i++ ) {
 			options.push( {
@@ -70,7 +70,7 @@ describe( 'Ordered Selected Options at the Top', () => {
 	} );
 
 	it( 'should return the given selected options when the collection is empty', () => {
-		const options = new Set< EntitiesSearch.ControlOption< string > >(
+		const options = new Set< Kensaku.ControlOption< string > >(
 			generateOptions()
 		);
 
@@ -83,7 +83,7 @@ describe( 'Ordered Selected Options at the Top', () => {
 	} );
 
 	it( 'should return the given options when the options are empty', () => {
-		const options = new Set< EntitiesSearch.ControlOption< string > >();
+		const options = new Set< Kensaku.ControlOption< string > >();
 
 		const result = orderSelectedOptionsAtTheTop(
 			options,

--- a/tests/client/unit/utils/unique-control-options.test.ts
+++ b/tests/client/unit/utils/unique-control-options.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import EntitiesSearch from '@types';
+import Kensaku from '@types';
 
 import { describe, expect, it } from '@jest/globals';
 
@@ -13,7 +13,7 @@ import { Set } from '../../../../sources/client/src/models/set';
 
 describe( 'Unique Control Options', () => {
 	it( 'Do not allow same control options within the same set', () => {
-		const set = new Set< EntitiesSearch.ControlOption< string > >( [
+		const set = new Set< Kensaku.ControlOption< string > >( [
 			{ label: 'foo', value: 'foo' },
 			{ label: 'bar', value: 'bar' },
 			{ label: 'foo', value: 'foo' },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = {
 		...baseConfiguration.output,
 		filename: '[name].js',
 		library: {
-			name: 'wpEntitiesSearch',
+			name: 'kensaku',
 			type: 'window',
 		},
 	},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Rebranding of the project from "Wp Entities Search" to "Kensaku" across the platform.
	- Namespace changes from `EntitiesSearch` to `Kensaku`, enhancing clarity and consistency.
	- Updated documentation to reflect new branding and ensure accuracy.

- **Bug Fixes**
	- Resolved issues in component references and imports related to the new naming conventions.

- **Documentation**
	- Comprehensive updates to README, API docs, and other documentation files to reflect the rebranding.

- **Chores**
	- Adjusted configuration files for consistency with the new project name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->